### PR TITLE
Fix tutorial 01 - Updated colab and nbviewer links

### DIFF
--- a/01-nuclear-energetics.ipynb
+++ b/01-nuclear-energetics.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/project-ida/nuclear/blob/master/01-nuclear-energetics.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href=\"https://nbviewer.jupyter.org/github/project-ida/nuclear/blob/master/01-nuclear-energetics.ipynb\" target=\"_parent\"><img src=\"https://nbviewer.jupyter.org/static/img/nav_logo.svg\" alt=\"Open In nbviewer\" width=\"100\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/project-ida/nuclear-reactions/blob/master/01-nuclear-energetics.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href=\"https://nbviewer.jupyter.org/github/project-ida/nuclear-reactions/blob/master/01-nuclear-energetics.ipynb\" target=\"_parent\"><img src=\"https://nbviewer.jupyter.org/static/img/nav_logo.svg\" alt=\"Open In nbviewer\" width=\"100\"/></a>"
    ]
   },
   {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# nuclear
+# nuclear-reactions
 
-This repo is dedicated to exploring nuclear processes.
+This repo is dedicated to exploring nuclear reactions.
 
 ## Tutorials
 

--- a/src/01-nuclear-energetics.md
+++ b/src/01-nuclear-energetics.md
@@ -13,7 +13,7 @@ jupyter:
     name: python3
 ---
 
-<a href="https://colab.research.google.com/github/project-ida/nuclear/blob/master/01-nuclear-energetics.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href="https://nbviewer.jupyter.org/github/project-ida/nuclear/blob/master/01-nuclear-energetics.ipynb" target="_parent"><img src="https://nbviewer.jupyter.org/static/img/nav_logo.svg" alt="Open In nbviewer" width="100"/></a>
+<a href="https://colab.research.google.com/github/project-ida/nuclear-reactions/blob/master/01-nuclear-energetics.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href="https://nbviewer.jupyter.org/github/project-ida/nuclear-reactions/blob/master/01-nuclear-energetics.ipynb" target="_parent"><img src="https://nbviewer.jupyter.org/static/img/nav_logo.svg" alt="Open In nbviewer" width="100"/></a>
 
 
 # Energetics of nuclear reactions


### PR DESCRIPTION
Changed the repo name from `nuclear` to `nuclear-reactions` to be more specific. The colab and nbviewer links needed to be updated accordingly.