### PR TITLE
Fixes colab and nbviewer links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ This repo is dedicated to exploring nuclear reactions. The notebooks contained i
 
 ## Tutorials
 
-- [Energetics of nuclear reactions](nuclear-energetics.ipynb)
-- [Fusion rates 01](fusion-rates-gamow.ipynb)
+- [Energetics of nuclear reactions](nuclear-energetics.ipynb) &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href="https://nbviewer.jupyter.org/github/project-ida/nuclear-reactions/blob/master/nuclear-energetics.ipynb" target="_parent"><img src="https://nbviewer.jupyter.org/static/img/nav_logo.svg" alt="Open In nbviewer" height="22"/></a>
+- [Fusion rates 01](fusion-rates-gamow.ipynb) &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href="https://nbviewer.jupyter.org/github/project-ida/nuclear-reactions/blob/master/fusion-rates-gamow.ipynb" target="_parent"><img src="https://nbviewer.jupyter.org/static/img/nav_logo.svg" alt="Open In nbviewer" height="22"/></a>

--- a/fusion-rates-gamow.ipynb
+++ b/fusion-rates-gamow.ipynb
@@ -5,7 +5,7 @@
    "id": "8151f8ad-7650-4410-966c-a19eb75c6f1d",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/project-ida/nuclear-reactions/blob/master/fusion-rates.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href=\"https://nbviewer.jupyter.org/github/project-ida/nuclear-reactions/blob/master/fusion-rates.ipynb\" target=\"_parent\"><img src=\"https://nbviewer.jupyter.org/static/img/nav_logo.svg\" alt=\"Open In nbviewer\" width=\"100\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/project-ida/nuclear-reactions/blob/master/fusion-rates-gamow.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href=\"https://nbviewer.jupyter.org/github/project-ida/nuclear-reactions/blob/master/fusion-rates-gamow.ipynb\" target=\"_parent\"><img src=\"https://nbviewer.jupyter.org/static/img/nav_logo.svg\" alt=\"Open In nbviewer\" width=\"100\"/></a>"
    ]
   },
   {

--- a/src/fusion-rates-gamow.md
+++ b/src/fusion-rates-gamow.md
@@ -13,7 +13,7 @@ jupyter:
     name: python3
 ---
 
-<a href="https://colab.research.google.com/github/project-ida/nuclear-reactions/blob/master/fusion-rates.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href="https://nbviewer.jupyter.org/github/project-ida/nuclear-reactions/blob/master/fusion-rates.ipynb" target="_parent"><img src="https://nbviewer.jupyter.org/static/img/nav_logo.svg" alt="Open In nbviewer" width="100"/></a>
+<a href="https://colab.research.google.com/github/project-ida/nuclear-reactions/blob/master/fusion-rates-gamow.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <a href="https://nbviewer.jupyter.org/github/project-ida/nuclear-reactions/blob/master/fusion-rates-gamow.ipynb" target="_parent"><img src="https://nbviewer.jupyter.org/static/img/nav_logo.svg" alt="Open In nbviewer" width="100"/></a>
 
 
 # Fusion rates 01


### PR DESCRIPTION
This PR, fixes the broken colab and nbviewer links in the recent fusion rates notebook. It also adds nbviewer links to the README